### PR TITLE
Add format questions script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Formatting question data
+
+Whenever the contents of `src/questions.js` are modified, run:
+
+```bash
+npm run format:questions
+```
+
+This formats the question explanations and writes the output back to `src/questions.js`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "format:questions": "node scripts/format_questions.js"
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- expose a script to reformat question data
- document how to use the formatting script

## Testing
- `npm run lint` *(fails: Parsing error in src/questions.js)*

------
https://chatgpt.com/codex/tasks/task_e_68791a44ca1c8322bed260d9097c1174